### PR TITLE
Add scripts for building pytorch wheels (based on their CI pipeline)

### DIFF
--- a/build_scripts/build_pytorch_wheel.sh
+++ b/build_scripts/build_pytorch_wheel.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -eux
+
+if [[ "$#" != 4 ]]; then
+  if [[ -z "$DESIRED_PYTHON" || -z "$DESIRED_CUDA" || -z "$PYTORCH_VERSION" || -z "$BUILDER_REVISION" ]]; then
+      echo "The env variabled DESIRED_PYTHON must be set like '2.7mu' or '3.6m' etc"
+      echo "The env variabled DESIRED_CUDA must be set like '11.1' or '10.2' etc"
+      echo "The env variabled PYTORCH_VERSION must be set like '1.8.0' or '1.7.1' etc"
+      echo "The env variabled BUILDER_REVISION must be set like 'master' or '4b78fd0f5bb0a2601146584239e377098cdc1ed9' etc"
+      exit 1
+  fi
+  desired_python="$DESIRED_PYTHON"
+  desired_cuda="$DESIRED_CUDA"
+  pytorch_version="$PYTORCH_VERSION"
+  builder_revision="$BUILDER_REVISION"
+else
+  desired_python="$1"
+  desired_cuda="$2"
+  pytorch_version="$3"
+  builder_revision="$4"
+fi
+
+CUDA_VERSION_NO_DOT=$(echo $desired_cuda | tr -d '.')
+MANYWHEELS_BUILD_DIR="_build/${pytorch_version}/manywheel/cu${CUDA_VERSION_NO_DOT}/"
+DESIRED_DEVTOOLSET="devtoolset7"
+
+cd "$(dirname "$0")"  # move inside the script directory
+mkdir -p "${MANYWHEELS_BUILD_DIR}"
+nvidia-docker run --rm -it \
+    --env CUDA_VERSION="${desired_cuda}" \
+    --env CUDA_VERSION_NO_DOT="${CUDA_VERSION_NO_DOT}" \
+    --env DESIRED_PYTHON="${desired_python}" \
+    --env PYTORCH_VERSION="${pytorch_version}" \
+    --env BUILDER_REVISION="${builder_revision}" \
+    --env DESIRED_DEVTOOLSET="${DESIRED_DEVTOOLSET}" \
+    --volume "$(pwd)/${MANYWHEELS_BUILD_DIR}:/remote" \
+    --volume "$(pwd)/entrypoint_build.sh:/entrypoint_build.sh" \
+    --entrypoint /entrypoint_build.sh \
+    "pytorch/manylinux-cuda${CUDA_VERSION_NO_DOT}"

--- a/build_scripts/entrypoint_build.sh
+++ b/build_scripts/entrypoint_build.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -eux
+
+# setting up git
+git config --global user.email "build@pytorch.org"
+git config --global user.name "PyTorch Builder"
+
+# cloning pytorch builder
+git clone https://github.com/pytorch/builder /builder
+if [[ -n "$BUILDER_REVISION" ]]; then
+    pushd .
+    cd /builder
+    echo "Checking out builder revision $BUILDER_REVISION"
+    git checkout "$BUILDER_REVISION"
+    popd
+fi
+
+# cloning pytorch in the proper place in the docker
+git clone -b "v${PYTORCH_VERSION}" --recursive https://github.com/pytorch/pytorch.git /pytorch
+
+# Begin exports
+export TZ=UTC
+export PYTORCH_BUILD_VERSION="${PYTORCH_VERSION}"
+echo "Running on $(uname -a) at $(date)"
+export PACKAGE_TYPE="manywheel"
+export DESIRED_PYTHON="$DESIRED_PYTHON"
+export DESIRED_CUDA="cu${CUDA_VERSION_NO_DOT}"
+export LIBTORCH_VARIANT="${LIBTORCH_VARIANT:-}"
+export BUILD_PYTHONLESS="${BUILD_PYTHONLESS:-}"
+export DESIRED_DEVTOOLSET="$DESIRED_DEVTOOLSET"
+export DATE="$(date -u +%Y%m%d)"
+
+export PYTORCH_BUILD_VERSION="${PYTORCH_VERSION}+${DESIRED_CUDA}"
+export PYTORCH_BUILD_NUMBER="1"
+export OVERRIDE_PACKAGE_VERSION="$PYTORCH_BUILD_VERSION"
+# TODO: We don't need this anymore IIUC
+export TORCH_PACKAGE_NAME='torch'
+export USE_FBGEMM=1
+
+
+JAVA_HOME=
+BUILD_JNI=OFF
+if [[ "$PACKAGE_TYPE" == libtorch ]]; then
+  POSSIBLE_JAVA_HOMES=()
+  POSSIBLE_JAVA_HOMES+=(/usr/local)
+  POSSIBLE_JAVA_HOMES+=(/usr/lib/jvm/java-8-openjdk-amd64)
+  POSSIBLE_JAVA_HOMES+=(/Library/Java/JavaVirtualMachines/*.jdk/Contents/Home)
+  # Add the Windows-specific JNI path
+  POSSIBLE_JAVA_HOMES+=("$PWD/.circleci/windows-jni/")
+  for JH in "${POSSIBLE_JAVA_HOMES[@]}" ; do
+    if [[ -e "$JH/include/jni.h" ]] ; then
+      # Skip if we're not on Windows but haven't found a JAVA_HOME
+      if [[ "$JH" == "$PWD/.circleci/windows-jni/" && "$OSTYPE" != "msys" ]] ; then
+        break
+      fi
+      echo "Found jni.h under $JH"
+      JAVA_HOME="$JH"
+      BUILD_JNI=ON
+      break
+    fi
+  done
+  if [ -z "$JAVA_HOME" ]; then
+    echo "Did not find jni.h"
+  fi
+fi
+export JAVA_HOME=$JAVA_HOME
+export BUILD_JNI=$BUILD_JNI
+
+# Pick docker image
+export DOCKER_IMAGE=${DOCKER_IMAGE:-}
+if [[ -z "$DOCKER_IMAGE" ]]; then
+    export DOCKER_IMAGE="pytorch/manylinux-cuda${DESIRED_CUDA:2}"
+fi
+
+export workdir="/"
+export PYTORCH_ROOT="$workdir/pytorch"
+export BUILDER_ROOT="$workdir/builder"
+
+export PYTORCH_FINAL_PACKAGE_DIR="/remote"
+
+export MAX_JOBS=${MAX_JOBS:-$(( $(nproc) - 2 ))}
+
+if [[ "${DESIRED_CUDA}" == "cu111" ]]; then
+  export BUILD_SPLIT_CUDA="ON"
+fi
+
+export OVERRIDE_TORCH_CUDA_ARCH_LIST="3.5;3.7;5.0;6.0;7.0"
+case ${CUDA_VERSION} in
+    11.[12])
+        export OVERRIDE_TORCH_CUDA_ARCH_LIST="${OVERRIDE_TORCH_CUDA_ARCH_LIST};7.5;8.0;8.6"
+        ;;
+    11.0)
+        export OVERRIDE_TORCH_CUDA_ARCH_LIST="${OVERRIDE_TORCH_CUDA_ARCH_LIST};7.5;8.0"
+        ;;
+    10.*)
+        export OVERRIDE_TORCH_CUDA_ARCH_LIST="${OVERRIDE_TORCH_CUDA_ARCH_LIST}"
+        ;;
+    9.*)
+        export OVERRIDE_TORCH_CUDA_ARCH_LIST="${OVERRIDE_TORCH_CUDA_ARCH_LIST}"
+        ;;
+    *)
+        echo "unknown cuda version $CUDA_VERSION"
+        exit 1
+        ;;
+esac
+# End exports
+
+SKIP_ALL_TESTS=1 "/builder/manywheel/build.sh"


### PR DESCRIPTION
The scripts of the `cron/` directory of the builder repo are a bit out of date, so this runs a build that more-closely mimics the way that binaries are actually created.


- Old nightly build for linux: app.circleci.com/pipelines/github/pytorch/pytorch/244138/workflows/33c04149-4020-44bc-8c85-695314e3252b/jobs/9234316
- Script that circleci uses to set environment variables https://github.com/pytorch/pytorch/blob/master/.circleci/scripts/binary_populate_env.sh
- CircleCI config for linux builds https://github.com/pytorch/pytorch/blob/master/.circleci/config.yml#L445-L450
- Postnightly builds: app.circleci.com/pipelines/github/pytorch/pytorch?branch=postnightly